### PR TITLE
Add support for cvParameters / character variant names

### DIFF
--- a/Lib/feaPyFoFum/feaPyFoFum.py
+++ b/Lib/feaPyFoFum/feaPyFoFum.py
@@ -1072,9 +1072,11 @@ class FeaSyntaxWriter(object):
             if (nameType := name["type"]) in orderedNames:
                 orderedNames[nameType].append(name)
             # XXX silently fail here?
-        for nameType in orderedNames:
+        for nameType, nameDicts in orderedNames.items():
+            if len(nameDicts) == 0:
+                continue
             block = [f"{self._whitespace}{nameType} {{"]
-            for name in orderedNames[nameType]:
+            for name in nameDicts:
                 text = name["text"]
                 platform = name.get("platform")
                 script = name.get("script")

--- a/Lib/feaPyFoFum/feaPyFoFum.py
+++ b/Lib/feaPyFoFum/feaPyFoFum.py
@@ -1057,3 +1057,53 @@ class FeaSyntaxWriter(object):
         self._indentText(text)
         self._identifierStack.append("stylisticSetNames")
         return text
+
+    # character variant
+
+    def formatCharacterVariantNames(self, *names):
+        lines = ["cvParameters {"]
+        orderedNames = dict(
+            FeatUILabelNameID=[],
+            FeatUITooltipTextNameID=[],
+            SampleTextNameID=[],
+            ParamUILabelNameID=[],
+        )
+        for name in names:
+            if (nameType := name["type"]) in orderedNames:
+                orderedNames[nameType].append(name)
+            # XXX silently fail here?
+        for nameType in orderedNames:
+            block = [f"{self._whitespace}{nameType} {{"]
+            for name in orderedNames[nameType]:
+                text = name["text"]
+                platform = name.get("platform")
+                script = name.get("script")
+                language = name.get("language")
+                line = ["name"]
+                if platform is not None:
+                    line.append(str(platform))
+                    if script is not None:
+                        line.append(str(script))
+                        line.append(str(language))
+                line.append(u'\"%s\"' % text)
+                line = (self._whitespace * 2) + " ".join(line) + ";"
+                block.append(line)
+            block.append((self._whitespace + "};"))
+            lines.extend(block)
+        lines.append("};")
+        text = "\n".join(lines)
+        return text
+
+    def characterVariantNames(self, *names):
+        d = dict(
+            identifier="characterVariantNames",
+            names=names
+        )
+        self._content.append(d)
+
+    def _characterVariantNames(self, names):
+        text = self._handleBreakBefore("characterVariantNames")
+        text.extend(self.formatCharacterVariantNames(*names).splitlines())
+        self._indentText(text)
+        self._identifierStack.append("characterVariantNames")
+        return text

--- a/readme.md
+++ b/readme.md
@@ -103,12 +103,27 @@ If `choice` is `True` the rule will be written as a `from` rule (GSUB LookupType
 
 The same contextual marking defined in the `substitution` method will be run for `ignoreSubstitution`.
 
-##### writer.stylisticSetFeatureNames(name1, name2, name3, ...)
+##### writer.stylisticSetNames(name1, name2, name3, ...)
 
 This will write the given names as `featureNames` in the current feature. Names must be dicts of this form:
 
 ```python
 name = {
+	"text" : "name for string",
+	"platform" : int, # optional
+	"script" : int, # optional
+	"language" : int, # optional
+}
+```
+
+##### writer.characterVariantNames(name1, name2, name3, ...)
+
+This will write the given names as `cvParameters` in the current feature. Names must be dicts of this form:
+
+```python
+name = {
+	"type": "type for this name",
+	# 'type' must be one of [FeatUILabelNameID, FeatUITooltipTextNameID, SampleTextNameID, ParamUILabelNameID]
 	"text" : "name for string",
 	"platform" : int, # optional
 	"script" : int, # optional
@@ -148,6 +163,8 @@ This will only assume that the substitution rule should contain contextual marki
 This will only assume that the substitution rule should contain contextual marking (`'`) if `lookahead` or `backtrack` are not None.
 
 ##### writer.formatStylisticSetNames(name1, name2, name3, ...)
+
+##### writer.formatCharacterVariantNames(name1, name2, name3, ...)
 
 
 # FeaPyFoFum


### PR DESCRIPTION
This would add support for the cvParameters block, that defines UI names for the cv01 to cv99 features (character variants). Accessible through **`writer.characterVariantNames`** (and **`writer.formatCharacterVariantNames`** for formatting).

The names dictionary would be of the following form:
```python
name = {
    "type": "type for this name",
    # 'type' must be one of [FeatUILabelNameID, FeatUITooltipTextNameID, SampleTextNameID, ParamUILabelNameID]
    "text" : "name for string",
    "platform" : int, # optional
    "script" : int, # optional
    "language" : int, # optional
}
```
I wonder whether the `formatCharacterVariantNames` method should fail silently or throw an error when the value for the `type` key of the dict is not one of _FeatUILabelNameID_, _FeatUITooltipTextNameID_, _SampleTextNameID_ or _ParamUILabelNameID_. Right now it just skips the name dict when it's not the case.

This pull request would also update the README to reflect the changes and fix the doc for `writer.stylisticSetNames` that was documented as `writer.stylisticSetFeatureNames`.